### PR TITLE
Add self-hosted Renovate for automated image bump PRs

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,38 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Renovate log level"
+        required: false
+        default: "info"
+        type: choice
+        options: ["debug", "info", "warn"]
+  schedule:
+    # Hourly at :17. Renovate's own "schedule" in renovate.json gates when it acts.
+    - cron: "17 * * * *"
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.14
+        env:
+          # Scope Renovate to just this repo (no autodiscovery across the org).
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Branch Renovate reads config from / opens PRs against.
+          RENOVATE_ONBOARDING: "false"
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+        with:
+          # PAT with `repo` + `workflow` scopes (a classic PAT) OR a fine-grained
+          # token with Contents:RW, Pull requests:RW, Workflows:RW on this repo.
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommitsDisabled"
+  ],
+  "timezone": "America/Chicago",
+  "schedule": ["at any time"],
+  "labels": ["dependencies", "docker"],
+  "packageRules": [
+    {
+      "description": "Group the core Zcash node container images into one PR",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "zfnd/zebra",
+        "electriccoinco/zcashd",
+        "electriccoinco/lightwalletd"
+      ],
+      "groupName": "zcash node container images"
+    },
+    {
+      "description": "Don't touch images intentionally pinned to :latest (busybox init, etc.)",
+      "matchCurrentValue": "/^latest$/",
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds **self-hosted Renovate** so the repo automatically opens PRs when newer Docker tags are published for our images.

- `renovate.json` — config (validated with Renovate's official `renovate-config-validator`).
- `.github/workflows/renovate.yml` — runs Renovate on an hourly cron + manual `workflow_dispatch`.

## What it tracks (via built-in managers, no fragile regex)

- **`helm-values`** manager → `charts/zcash-stack/values.yaml`: `zfnd/zebra`, `electriccoinco/zcashd`, `electriccoinco/lightwalletd`, `emersonian/zcash-explorer`, `emersonian/zcash-zaino`, `osminogin/tor-simple`.
- **`docker-compose`** manager → `docker/compose.*.yaml` image refs.

The three core node images (`zebra` / `zcashd` / `lightwalletd`) are grouped into one PR. Images pinned to `:latest` (busybox init containers, etc.) are intentionally left alone.

## ⚠️ Required before this works

1. Create a PAT (classic: `repo` + `workflow` scopes — or fine-grained with Contents/Pull requests/Workflows: RW on this repo).
2. Add it as repo secret **`RENOVATE_TOKEN`** (Settings → Secrets and variables → Actions).
3. Merge, then run the **Renovate** workflow manually once (Actions tab → Renovate → Run workflow) to bootstrap the Dependency Dashboard issue.

Without the secret the workflow runs but can't open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)