### PR TITLE
The environment variables for `zebrad` caused runtime errors.

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -4,7 +4,7 @@
 #####
 
 RUST_LOG=info
-ZEBRA_FORCE_USE_COLOR=1
+ZEBRA_TRACING__FORCE_USE_COLOR=1
 LOG_COLOR=true
 
 # When using lightwalletd, you can enter your Zcash donation address
@@ -20,19 +20,16 @@ LIGHTWALLETD_DONATION_ADDRESS=u14yr5fr2gzhedzrlmymtjp8jqsdryh6zpypnh8k2e2hq9z6jl
 # See also its `entrypoint.sh` script for more details on them.
 #####
 
-# The config file full path used in the Dockerfile.
-ZEBRA_CONF_PATH=/etc/zebrad/zebrad.toml
-
 # [network]
 NETWORK=Mainnet
-ZEBRA_LISTEN_ADDR=0.0.0.0
+ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0
 
 # [consensus]
-ZEBRA_CHECKPOINT_SYNC=true
+ZEBRA_CONSENSUS__CHECKPOINT_SYNC=true
 
 # [state]
 # Set this to change the default cached state directory
-ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache
+ZEBRA_STATE__CACHE_DIR=/var/cache/zebrad-cache
 LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache
 
 # [metrics]


### PR DESCRIPTION
The [`zebrad` configuration struct](https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html) expects environment variables to name the section in which they reside before the field itself. This avoids an error such as:

```
error: zebrad fatal error: I/O operation failed: Configuration error: unknown field `cached_state_dir`, expected one of `consensus`, `metrics`, `network`, `state`, `tracing`, `sync`, `mempool`, `rpc`, `mining`, `health`
```

when starting up.