### PR TITLE
fix(docker): make compose.caddy.yaml parseable and functional

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -48,3 +48,18 @@ RPC_PORT=8232
 # Uncomment if you are using a VPS proxy server and setting up an
 # SSH reverse tunnel (for IP privacy) with `compose.autossh.yaml`.
 #VPS_IP=
+
+#####
+# Caddy Configuration Variables
+#
+# Used by `compose.caddy.yaml` to expose the lightwalletd gRPC endpoint over a
+# TLS endpoint on :443 with an automatic Let's Encrypt certificate.
+#####
+
+# Public DNS name that resolves to this host. Caddy obtains a certificate for
+# it and terminates TLS on :443. Leave unset to fall back to `localhost`
+# (Caddy issues an internal self-signed cert, useful only for local testing).
+LIGHTWALLETD_DOMAIN=
+
+# Email used for the ACME (Let's Encrypt) account and certificate-expiry notices.
+CADDY_EMAIL=

--- a/docker/compose.caddy.yaml
+++ b/docker/compose.caddy.yaml
@@ -3,6 +3,15 @@
 # In this file, we bring up a Caddy HTTP server. We like Caddy for
 # the ease with which it gives us the ability to configure a TLS
 # endpoint for our node, since it has a built-in Let's Encrypt tool.
+#
+# Caddy terminates TLS on :443 and reverse-proxies to lightwalletd's gRPC
+# endpoint. Use it as an overlay on top of compose.yaml, which provides the
+# lightwalletd service:
+#
+#   docker compose -f compose.yaml -f compose.caddy.yaml up --detach
+#
+# Set LIGHTWALLETD_DOMAIN (a public DNS name pointing at this host) and
+# CADDY_EMAIL (your ACME account email) in .env before bringing it up.
 ---
 services:
   caddy:
@@ -19,15 +28,6 @@ services:
       - ./data/caddy_config:/config
     environment:
       - CADDY_EMAIL=${CADDY_EMAIL:-example@domain.com}
-    depends_on:
-      - lightwalletd 
       - LIGHTWALLETD_DOMAIN=${LIGHTWALLETD_DOMAIN:-localhost}
     depends_on:
-      - lightwalletd 
-    networks:
-      - zcash-network
-
-networks:
-  zcash-network:
-    external: true
-    name: zcash-network 
+      - lightwalletd

--- a/docker/configs/Caddyfile
+++ b/docker/configs/Caddyfile
@@ -1,0 +1,14 @@
+# Caddyfile for compose.caddy.yaml.
+#
+# Caddy obtains a Let's Encrypt certificate for $LIGHTWALLETD_DOMAIN and
+# terminates TLS on :443, forwarding to lightwalletd's gRPC endpoint.
+# Both variables come from the caddy service's environment (see .env).
+{
+	email {$CADDY_EMAIL}
+}
+
+{$LIGHTWALLETD_DOMAIN} {
+	# lightwalletd serves gRPC as plaintext HTTP/2 on 9067 (see compose.yaml);
+	# proxy to it over h2c (HTTP/2 cleartext).
+	reverse_proxy h2c://lightwalletd:9067
+}


### PR DESCRIPTION
## Problem

`docker/compose.caddy.yaml` cannot be parsed by Docker Compose:

```
$ docker compose -f compose.yaml -f compose.caddy.yaml config
failed to parse compose.caddy.yaml: yaml: construct errors:
  line 25: mapping key "depends_on" already defined at line 22
```

Because the file fails to parse, the Caddy TLS overlay cannot be used at all. Anyone following the workshop to put their node behind TLS hits this immediately.

There are three defects in the file, plus a fourth that would surface as soon as it parses:

1. **Duplicate `depends_on` key** (lines 22 and 25). This is a hard YAML parse error, not a last-one-wins merge.
2. **An environment variable listed as a service dependency.** `- LIGHTWALLETD_DOMAIN=${LIGHTWALLETD_DOMAIN:-localhost}` sits inside `depends_on`, where it has no effect.
3. **A bind mount of `./configs/Caddyfile`, which does not exist in the repository.** `git ls-files` tracks no Caddyfile. Neither `LIGHTWALLETD_DOMAIN` nor `CADDY_EMAIL` is defined in `docker/.env`, so even once the file parsed, Caddy would start with no usable configuration.
4. **Network mismatch.** The `caddy` service joins an `external: true` network named `zcash-network`, but the services in `compose.yaml` use the default project network. Caddy could not resolve `lightwalletd` by name.

## Changes

- Remove the duplicate `depends_on` and the misplaced variable, keeping a single `depends_on: [lightwalletd]`.
- Move `LIGHTWALLETD_DOMAIN` into the caddy service `environment`, next to the existing `CADDY_EMAIL`, so the Caddyfile can read it.
- Drop the external network block so caddy shares the default project network with `lightwalletd`.
- Add `docker/configs/Caddyfile`. It obtains a Let's Encrypt certificate for `{$LIGHTWALLETD_DOMAIN}` and reverse proxies to lightwalletd gRPC on port `9067` over h2c. Port 9067 is lightwalletd's `--grpc-bind-addr` in `compose.yaml`.
- Document `LIGHTWALLETD_DOMAIN` and `CADDY_EMAIL` in `docker/.env`.

Scope is deliberately limited to making this one overlay work. `compose.vps.yaml`, which is the Cloudflare and tunnel oriented variant, is untouched.

## Verification

```bash
# 1. Parses cleanly now. This previously failed with the error above.
docker compose -f compose.yaml -f compose.caddy.yaml config    # exits 0

# 2. caddy and lightwalletd share the default project network.
docker compose -f compose.yaml -f compose.caddy.yaml config --format json \
  | jq '{caddy: .services.caddy.networks, lightwalletd: .services.lightwalletd.networks}'
# => {"caddy":{"default":null},"lightwalletd":{"default":null}}

# 3. The Caddyfile is valid.
docker run --rm -e CADDY_EMAIL=a@b.co -e LIGHTWALLETD_DOMAIN=localhost \
  -v "$PWD/configs/Caddyfile":/etc/caddy/Caddyfile:ro \
  caddy:latest caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
# => "Valid configuration"
```

All three checks pass.

The same TLS to h2c arrangement is also running in practice against mainnet. On a node built from this repository, Caddy obtained a Let's Encrypt certificate and `GetLightdInfo` returns correctly through it on port 443:

```
$ grpcurl -import-path proto -proto service.proto \
    <domain>:443 cash.z.wallet.sdk.rpc.CompactTxStreamer/GetLightdInfo
{
  "version": "v0.4.19",
  "vendor": "ECC LightWalletD",
  "chainName": "main",
  "blockHeight": "3424351",
  "estimatedHeight": "3424356",
  "zcashdSubversion": "/Zebra:6.2.2/"
}
```

## Notes

Operators who want no request logging can add the following inside the site block, which is what the deployment above uses:

```
log {
	output discard
}
```
